### PR TITLE
Fix m_rgEnemies property renamed to m_mapEnemies

### DIFF
--- a/salienGameBot.user.js
+++ b/salienGameBot.user.js
@@ -274,7 +274,7 @@ context.BOT_FUNCTION = function ticker(delta) {
 
     let state = EnemyManager();
 
-    let enemies = state.m_rgEnemies;
+    let enemies = state.m_mapEnemies;
 
     for (let attack of attacks)
         if (attack.shouldAttack(delta, enemies))


### PR DESCRIPTION
Latest version of the game was erroring out because of a property rename.